### PR TITLE
Update OSU Icons URL in plugin files

### DIFF
--- a/js/plugins/osu_icons/dialogs/osu_icons.js
+++ b/js/plugins/osu_icons/dialogs/osu_icons.js
@@ -85,7 +85,7 @@ CKEDITOR.dialog.add("osu_iconsDialog", function(editor) {
 
       // Load OSU Icons from json file
       const osuIconUrl =
-        "https://cdn.icomoon.io/155267/OregonStateBrandIcons/selection.json?8rsof6";
+        "https://cdn.icomoon.io/155267/OregonStateBrandIcons/selection.json?6642o2";
       $.getJSON(osuIconUrl, function(data) {
         $.each(data.icons, function(key, val) {
           $(`${e_class} .osu-icons`).append(

--- a/js/plugins/osu_icons/plugin.js
+++ b/js/plugins/osu_icons/plugin.js
@@ -6,7 +6,7 @@
       // Add plugin CSS to allow icons to be rendered in current editor.
       const cssPath = `${this.path}styles/osu_icons.css`;
       const osuIconUrl =
-        'https://cdn.icomoon.io/155267/OregonStateBrandIcons/style-cf.css?8rsof6';
+        'https://cdn.icomoon.io/155267/OregonStateBrandIcons/style-cf.css?6642o2';
 
       editor.addContentsCss(cssPath);
       CKEDITOR.document.appendStyleSheet(cssPath);


### PR DESCRIPTION
Updated the CSS and JSON URLs for OSU icons to new versions in `plugin.js` and `osu_icons.js` files. This ensures the icons are retrieved from the correct updated URLs.